### PR TITLE
Unify hotspotter and hotspotter-analyze into single CLI with --report

### DIFF
--- a/openspec/changes/archive/2026-02-03-unify-hotspotter-cli/design.md
+++ b/openspec/changes/archive/2026-02-03-unify-hotspotter-cli/design.md
@@ -1,0 +1,74 @@
+# Design: Unify Hotspotter CLI
+
+## Goal
+
+Merge the two scripts (`hotspotter` and `hotspotter-analyze`) into a single `hotspotter` command. The user controls whether to run only Phase 1 (git data) or Phase 1 + Phase 2 (report) via a `--report` flag.
+
+## Flow
+
+```
+hotspotter [options] [--report]
+                │
+                ▼
+        Phase 1: gather git data
+        (hotspot detection, coupling, same as today)
+                │
+                ▼
+        ┌───────────────┐
+        │ --report set? │
+        └───────┬───────┘
+                │
+    No ─────────┴───────── Yes
+     │                      │
+     ▼                      ▼
+  Output Phase 1       Write JSON and report
+  (table or --output    to --output (both files)
+   for JSON only),      then run analysis step
+   then exit
+                                │
+                                ▼
+                        Run analysis step
+                        (same logic as current
+                         hotspotter-analyze)
+                                │
+                                ▼
+                        Report written to
+                        path derived from --output
+```
+
+- **Without `--report`**: Run Phase 1. If `--output` is set, write JSON only to that path; else print table to stdout. Then stop.
+- **With `--report`**: Run Phase 1, write **both** JSON and report. Paths are derived from `--output` (see below). Then run the analysis step; report is written to the derived report path.
+
+## Single `--output` for both JSON and report
+
+One flag, `--output`, controls where output is written:
+
+| Mode        | `--output` set? | Behavior |
+|-------------|-----------------|----------|
+| No `--report` | No              | Print Phase 1 table to stdout. |
+| No `--report` | Yes             | Write Phase 1 JSON to `--output` (current behavior). |
+| `--report`   | No              | Need a rule: e.g. require `--output` when `--report`, or use a default base path (e.g. `./hotspotter` → `./hotspotter.json` + `./hotspotter.md`). |
+| `--report`   | Yes             | Write **both** JSON and report. Treat `--output` as a **base path**: write JSON to `{base}.json` and report to `{base}.md`. If user passes `--output report.md`, base is `report` → `report.json` and `report.md`. If `--output out`, write `out.json` and `out.md`. |
+
+So: without `--report`, `--output` is the literal JSON file path. With `--report`, `--output` is the base for both files (strip extension if present to get base, then `{base}.json` and `{base}.md`).
+
+## Data handoff when `--report`
+
+When `--report` is set, Phase 1 JSON is written to the derived path (`{base}.json`). That path is passed to the analysis step; the agent reads it and writes the report to the derived report path (`{base}.md`). No temp file needed when `--output` is set. If `--report` is set but `--output` is not (if we allow that), use a temp file for JSON and a default path for the report, or require `--output` when `--report`.
+
+## Entrypoints: only unify
+
+- **Single binary**: Only `hotspotter` in `package.json` `bin`. Remove `hotspotter-analyze`.
+- **No separate “analyze only” command**: The previous two-step workflow becomes a single invocation: `hotspotter --report --output report ...` (writes `report.json` and `report.md`).
+
+## CLI surface (additions)
+
+- `--report`: If present, after Phase 1 run the analysis step and write both JSON and report (paths from `--output`).
+- `--output`: Unchanged when `--report` is not set (JSON path only). When `--report` is set, treated as base path for both JSON (`{base}.json`) and report (`{base}.md`).
+- When `--report`: require `--output` (so we always have a base path), or define a default base (e.g. `./hotspotter`).
+- Analysis step: workspace from Phase 1 `--path`, optional `--model`; pass through when `--report` is set.
+
+## Out of scope
+
+- Keeping `hotspotter-analyze` as a separate or deprecated entrypoint.
+- Changing how the agent or prompt work; they continue to receive a file path to the Phase 1 JSON.

--- a/openspec/changes/archive/2026-02-03-unify-hotspotter-cli/proposal.md
+++ b/openspec/changes/archive/2026-02-03-unify-hotspotter-cli/proposal.md
@@ -1,0 +1,31 @@
+# Proposal: Unify Hotspotter CLI
+
+## Why
+
+Today users run two commands: `hotspotter` (Phase 1: git data) and `hotspotter-analyze` (Phase 2: AI report). That two-step workflow is easy to forget and adds friction. A single command with an optional `--report` flag keeps one entrypoint and lets users choose “data only” or “data + report” without switching tools.
+
+## What Changes
+
+- **Single `hotspotter` command** with optional `--report`. Without `--report`, run Phase 1 only and show output (table or JSON to `--output`); then stop. With `--report`, run Phase 1, then the analysis step, and write both JSON and markdown report.
+- **Single `--output`** for both artifacts: without `--report`, `--output` is the JSON path only (current behavior). With `--report`, `--output` is a base path: write `{base}.json` and `{base}.md`.
+- **BREAKING**: Remove `hotspotter-analyze` from `package.json` bin. There is no separate “analyze only” command.
+- When `--report` is set, require `--output` (or define a default base path) so both files have a destination.
+- Analysis step (workspace, model) is unchanged; it is invoked internally when `--report` is set.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- **hotspotter**: CLI is a single command. New flag `--report`; `--output` semantics extended so that with `--report` it is the base path for both JSON and report. Phase 1 behavior unchanged when `--report` is not set.
+- **ai-analysis**: No longer a standalone CLI. Report generation is triggered by `hotspotter --report`; the same analysis logic runs with Phase 1 JSON (written to the derived path). Invocation and contract (file path in, report path out) unchanged; only the entrypoint is removed.
+
+## Impact
+
+- **package.json**: Remove `hotspotter-analyze` from `bin`; only `hotspotter` remains.
+- **src/index.ts**: Add `--report`; when set, after Phase 1 write JSON (and report path) from `--output` base, then invoke analysis step (same logic as current `analyze.ts`).
+- **src/analyze.ts**: Logic is reused by the main CLI (e.g. extracted so `index.ts` can call it). The file may remain as a module or be inlined; the binary entrypoint is removed.
+- **Users**: Existing two-step usage (“run hotspotter, then hotspotter-analyze”) becomes a single `hotspotter --report --output <base> ...` call.

--- a/openspec/changes/archive/2026-02-03-unify-hotspotter-cli/specs/ai-analysis/spec.md
+++ b/openspec/changes/archive/2026-02-03-unify-hotspotter-cli/specs/ai-analysis/spec.md
@@ -1,0 +1,22 @@
+# AI Analysis (unify-hotspotter-cli)
+
+## MODIFIED Requirements
+
+### Requirement: Report generation via hotspotter
+
+Report generation SHALL be triggered by running the single `hotspotter` command with the `--report` flag. The same analysis logic (AI agent, prompt, report format) SHALL run when `--report` is set; Phase 1 JSON SHALL be written to the path derived from `--output` and the agent SHALL read that file and write the report to the derived report path. There SHALL be no separate `hotspotter-analyze` binary.
+
+#### Scenario: Report via unified command
+
+- **WHEN** the user runs `hotspotter --path <path> --since <date> --report --output <base>`
+- **THEN** Phase 1 runs and JSON is written to `{base}.json`
+- **AND** the analysis step runs with that JSON path and workspace from `--path`
+- **AND** the markdown report is written to `{base}.md` with the same format and sections as before
+
+## REMOVED Requirements
+
+### Requirement: Standalone hotspotter-analyze CLI
+
+**Reason**: Unified into the single `hotspotter` command; report generation is triggered by `--report`.
+
+**Migration**: Use `hotspotter --report --output <base> --path <path> --since <date> ...` instead of running `hotspotter --output hotspots.json ...` then `hotspotter-analyze --input hotspots.json --output report.md --workspace <path>`.

--- a/openspec/changes/archive/2026-02-03-unify-hotspotter-cli/specs/hotspotter/spec.md
+++ b/openspec/changes/archive/2026-02-03-unify-hotspotter-cli/specs/hotspotter/spec.md
@@ -1,0 +1,50 @@
+# Hotspotter (unify-hotspotter-cli)
+
+## MODIFIED Requirements
+
+### Requirement: Single CLI entrypoint and report flag
+
+The tool SHALL expose a single command `hotspotter`. Phase 2 (AI-powered refactoring report) SHALL be triggered by an optional `--report` flag. When `--report` is not set, only Phase 1 (hotspot detection and coupling) runs and the process exits after output.
+
+#### Scenario: Without --report
+
+- **WHEN** the user runs `hotspotter --path <path> --since <date>` without `--report`
+- **THEN** Phase 1 (hotspot detection and coupling) runs
+- **AND** output is either CSV to stdout (if `--output` is not set) or JSON written to the path given by `--output`
+- **AND** the process exits without running the analysis step
+
+#### Scenario: With --report
+
+- **WHEN** the user runs `hotspotter --path <path> --since <date> --report --output <base>`
+- **THEN** Phase 1 runs
+- **AND** JSON is written to `{base}.json` and the markdown report is written to `{base}.md`
+- **AND** the analysis step (AI agent) runs and writes the report to the derived path
+
+### Requirement: Output path semantics
+
+The `--output` flag SHALL control where Phase 1 output is written. When `--report` is not set, `--output` is the literal path for the JSON file (or omitted for CSV to stdout). When `--report` is set, `--output` SHALL be interpreted as a base path: JSON at `{base}.json` and report at `{base}.md` (extension stripped from the given path to form the base, if present).
+
+#### Scenario: No report, no output
+
+- **WHEN** the user runs `hotspotter` without `--output` and without `--report`
+- **THEN** Phase 1 results are displayed as CSV on stdout
+
+#### Scenario: No report, with output
+
+- **WHEN** the user runs `hotspotter` with `--output <path>` and without `--report`
+- **THEN** Phase 1 JSON is written to the literal path `<path>`
+
+#### Scenario: Report, with output
+
+- **WHEN** the user runs `hotspotter` with `--report` and `--output <base>` (e.g. `report` or `report.md`)
+- **THEN** Phase 1 JSON is written to `{base}.json`
+- **AND** the markdown report is written to `{base}.md`
+
+### Requirement: Command-line arguments for report mode
+
+When `--report` is set, `--output` SHALL be required (or a default base path SHALL be used) so both JSON and report have a destination. The repository path for the analysis step SHALL be taken from `--path`. An optional `--model` flag MAY be passed through to the analysis step.
+
+#### Scenario: Report requires output
+
+- **WHEN** the user runs `hotspotter --report ...` with `--output <base>` set
+- **THEN** both `{base}.json` and `{base}.md` are written

--- a/openspec/changes/archive/2026-02-03-unify-hotspotter-cli/tasks.md
+++ b/openspec/changes/archive/2026-02-03-unify-hotspotter-cli/tasks.md
@@ -1,0 +1,21 @@
+## 1. CLI surface
+
+- [x] 1.1 Add `--report` flag to the hotspotter program (Commander option; no behavior yet).
+- [x] 1.2 Implement base-path derivation from `--output` when `--report` is set: strip extension to get base, then `{base}.json` and `{base}.md`. When `--report` is not set, keep current behavior: `--output` is the literal JSON path.
+- [x] 1.3 When `--report` is set, require `--output` (or use a default base path) and validate before running Phase 1.
+
+## 2. Phase 1 output and report wiring
+
+- [x] 2.1 When `--report` is set, after Phase 1 write JSON to the derived path `{base}.json` (same structure as today). If `--report` is not set, keep existing behavior (table or JSON to `--output`).
+- [x] 2.2 Extract or reuse the analysis step from `src/analyze.ts` so it can be invoked with (input JSON path, output report path, workspace path, optional model). Do not change agent or prompt behavior.
+- [x] 2.3 When `--report` is set, after writing Phase 1 JSON, invoke the analysis step with the derived JSON path, derived report path `{base}.md`, workspace from `--path`, and optional `--model`. Pass through any existing analysis options.
+
+## 3. Remove separate analyze binary
+
+- [x] 3.1 Remove `hotspotter-analyze` from `package.json` `bin`. Only `hotspotter` remains.
+- [x] 3.2 Ensure `src/analyze.ts` is no longer an entrypoint; its logic is either called from `src/index.ts` or required as a module. Delete or refactor the Commander program in `analyze.ts` so it is not a standalone script.
+
+## 4. Tests
+
+- [x] 4.1 Add or update tests for argument parsing: `--report` present/absent, `--output` with and without `--report`, and base-path derivation (`{base}.json`, `{base}.md`).
+- [x] 4.2 Add tests (or integration-style tests) that when `--report` is set the analysis step is invoked with the correct paths; use mocks for the actual agent spawn so tests do not depend on the agent binary.

--- a/openspec/specs/ai-analysis/spec.md
+++ b/openspec/specs/ai-analysis/spec.md
@@ -1,23 +1,24 @@
-# AI Analysis (hotspotter-analyze)
+# AI Analysis
 
 ## Overview
 
-After generating a hotspots report with the main Hotspotter CLI, the `hotspotter-analyze` script uses an AI agent to produce human-readable refactoring recommendations. It reads the JSON output from Hotspotter, analyzes hotspot clusters and coupling relationships, and writes a structured markdown report.
+Report generation is triggered by running the single `hotspotter` command with the `--report` flag. The same analysis logic (AI agent, prompt, report format) runs when `--report` is set: hotspot data JSON is written to the path derived from `--output`, and the agent reads that file and writes the structured markdown report to the derived report path. There is no separate `hotspotter-analyze` binary.
 
 ## Workflow
 
-The script:
+When the user runs `hotspotter --report --output <base> ...`:
 
-1. Reads the JSON output from the main Hotspotter tool (Phase 1)
-2. Analyzes hotspot clusters and coupling relationships
-3. Generates human-readable refactoring recommendations
-4. Identifies high-risk areas and priority refactoring opportunities
+1. Data gathering runs and JSON is written to `{base}.json`
+2. The AI agent runs with that JSON path and workspace from `--path`
+3. The markdown report is written to `{base}.md` with the same format and sections as before
 
 ## Invocation
 
 ```bash
-hotspotter-analyze --input hotspots.json --output analysis.md --workspace /path/to/repo
+hotspotter --path /path/to/repo --since "12 months ago" --report --output report
 ```
+
+This writes `report.json` and `report.md`.
 
 ## Report Format
 
@@ -43,7 +44,4 @@ The agent reads the actual source code files to provide code-aware recommendatio
 
 ## Command-Line Arguments
 
-- `--input <file>` (required): Path to the JSON output file from Hotspotter
-- `--output <file>` (required): Path to the output markdown file for the analysis
-- `--workspace <path>` (optional): Workspace directory for context
-- `--model <model>` (optional): AI model to use for analysis
+Report generation uses the same arguments as the main `hotspotter` command. When `--report` is set, `--path` is the workspace (repository) for the agent, and `--output` is the base path for both the hotspot data JSON and the report markdown (see [Hotspotter](hotspotter) spec).

--- a/openspec/specs/hotspotter/spec.md
+++ b/openspec/specs/hotspotter/spec.md
@@ -26,7 +26,7 @@ The tool operates in two main phases:
 
 ### Phase 2: AI-Powered Refactoring Recommendations
 
-A separate analysis script (`hotspotter-analyze`) uses an AI agent to produce refactoring recommendations from the Phase 1 output. See the [AI Analysis](ai-analysis) spec.
+Report generation is triggered by the optional `--report` flag. When `--report` is set, after Phase 1 the same analysis logic (AI agent, prompt, report format) runs and writes the markdown report. See the [AI Analysis](ai-analysis) spec. There is no separate `hotspotter-analyze` binary.
 
 ## Hotspot Detection Method
 
@@ -131,7 +131,8 @@ This analysis helps identify:
 - `--percentage <number>` (optional): Percentage threshold for hotspot selection (default: 10)
 - `--limit <number>` (optional): Maximum number of results to include in the analysis (default: 30)
 - `--coupling-threshold <number>` (optional): Minimum coupling count to include in coupling results (default: 5). Set to 0 to disable filtering and include all couplings.
-- `--output <file>` (optional): Output file path for JSON results. If not specified, results are displayed as CSV in the console.
+- `--output <file>` (optional): When `--report` is not set: path for JSON results (if not specified, results are displayed as CSV in the console). When `--report` is set: base path for both outputs—JSON is written to `{base}.json` and the report to `{base}.md` (any extension on the path is stripped to form the base). `--output` is required when `--report` is set.
+- `--report` (optional): After data gathering, run report generation and write both JSON and report (requires `--output`).
 - `--exclude <pattern>` (optional): Regex pattern to exclude files from analysis. Can be specified multiple times to exclude multiple patterns. Files matching any of the patterns will be filtered out before analysis.
 
 ## Usage Example
@@ -170,4 +171,10 @@ Exclude files matching patterns:
 
 ```bash
 hotspotter --path /path/to/repo --since "12 months ago" --exclude "\.lock$" --exclude "\.json$" --exclude "node_modules/"
+```
+
+Run data gathering and report generation (writes `report.json` and `report.md`):
+
+```bash
+hotspotter --path /path/to/repo --since "12 months ago" --report --output report
 ```

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "dist/index.js",
   "type": "module",
   "bin": {
-    "hotspotter": "./dist/index.js",
-    "hotspotter-analyze": "./dist/analyze.js"
+    "hotspotter": "./dist/index.js"
   },
   "scripts": {
     "build": "tsc",

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,116 +1,70 @@
-#!/usr/bin/env node
-
-import { Command } from "commander";
 import { readFile } from "fs/promises";
 import { spawn } from "child_process";
-import { dirname, join } from "path";
+import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 
-const program = new Command();
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
-program
-  .name("hotspotter-analyze")
-  .description(
-    "Analyze Hotspotter report using AI agent to identify refactoring opportunities"
-  )
-  .requiredOption(
-    "--input <file>",
-    "Path to the JSON output file from Hotspotter"
-  )
-  .requiredOption(
-    "--output <file>",
-    "Path to the output markdown file where the agent will save the analysis"
-  )
-  .option(
-    "--workspace <path>",
-    "Workspace directory (repository path) for context",
-    process.cwd()
-  )
-  .option("--model <model>", "Model to use for analysis")
-  .action(async (options) => {
-    try {
-      // Read the JSON input file to extract repository path
-      const jsonContent = await readFile(options.input, "utf-8");
-      const data = JSON.parse(jsonContent);
+/**
+ * Run report generation: spawn the AI agent to read the hotspot data JSON and write the report.
+ * Used when hotspotter is invoked with --report.
+ */
+export async function runAnalysis(
+  inputFilePath: string,
+  outputFilePath: string,
+  workspacePath: string
+): Promise<void> {
+  const absoluteInputPath = resolve(inputFilePath);
+  const prompt = await createAnalysisPrompt(absoluteInputPath, outputFilePath);
 
-      // Extract repository path from arguments
-      const repoPath = data.arguments?.path || options.workspace;
+  const agentArgs = ["--workspace", workspacePath, prompt];
 
-      // Get absolute path to input file for the agent to read
-      const { resolve } = await import("path");
-      const inputFilePath = resolve(options.input);
+  console.error("Starting AI agent in interactive mode...");
+  console.error(
+    "The agent will analyze the hotspots and ask if you want to save the results.\n"
+  );
 
-      // Build the agent command arguments for interactive mode
-      let agentArgs = ["--workspace", repoPath];
+  return new Promise<void>((resolvePromise, reject) => {
+    const agentProcess = spawn("agent", agentArgs, {
+      stdio: ["inherit", "inherit", "inherit"],
+    });
 
-      if (options.model) {
-        agentArgs.push("--model", options.model);
+    agentProcess.on("close", (code) => {
+      if (code === 0) {
+        resolvePromise();
+      } else {
+        reject(new Error(`Agent process exited with code ${code}`));
+      }
+    });
+
+    agentProcess.on("error", (error) => {
+      console.error("\n✗ Error starting agent process:");
+      console.error(`  ${error.message}`);
+
+      if (
+        error.message.includes("ENOENT") ||
+        error.message.includes("spawn")
+      ) {
+        console.error(
+          '\n  This usually means the "agent" command is not found.'
+        );
+        console.error(
+          "  Make sure Cursor Agent is installed and available in your PATH."
+        );
+        console.error(
+          "  You may need to install it or add it to your PATH."
+        );
       }
 
-      // Load prompt template and inject paths
-      const prompt = await createAnalysisPrompt(inputFilePath, options.output);
-
-      agentArgs.push(prompt);
-
-      console.error("Starting AI agent in interactive mode...");
-      console.error(
-        "The agent will analyze the hotspots and ask if you want to save the results.\n"
-      );
-
-      // Execute the agent in interactive mode (no --print flag)
-      return new Promise<void>((resolve, reject) => {
-        const agentProcess = spawn("agent", agentArgs, {
-          stdio: ["inherit", "inherit", "inherit"],
-        });
-
-        agentProcess.on("close", (code) => {
-          if (code === 0) {
-            resolve();
-          } else {
-            reject(new Error(`Agent process exited with code ${code}`));
-          }
-        });
-
-        agentProcess.on("error", (error) => {
-          console.error("\n✗ Error starting agent process:");
-          console.error(`  ${error.message}`);
-
-          if (
-            error.message.includes("ENOENT") ||
-            error.message.includes("spawn")
-          ) {
-            console.error(
-              '\n  This usually means the "agent" command is not found.'
-            );
-            console.error(
-              "  Make sure Cursor Agent is installed and available in your PATH."
-            );
-            console.error(
-              "  You may need to install it or add it to your PATH."
-            );
-          }
-
-          reject(new Error(`Failed to start agent: ${error.message}`));
-        });
-      });
-    } catch (error) {
-      console.error(
-        "Error:",
-        error instanceof Error ? error.message : String(error)
-      );
-      process.exit(1);
-    }
+      reject(new Error(`Failed to start agent: ${error.message}`));
+    });
   });
-
-program.parse();
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+}
 
 async function createAnalysisPrompt(
   inputFilePath: string,
   outputFilePath: string
 ): Promise<string> {
-  // When running from dist/analyze.js, prompt lives in src/prompt.md
   const promptPath = join(__dirname, "..", "src", "prompt.md");
   const template = await readFile(promptPath, "utf-8");
   return template

--- a/src/args.test.ts
+++ b/src/args.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseArgs } from "./args.js";
+import { parseArgs, getReportOutputPaths } from "./args.js";
 
 describe("parseArgs", () => {
   describe("valid options", () => {
@@ -19,8 +19,35 @@ describe("parseArgs", () => {
         limit: 30,
         couplingThreshold: 5,
         output: undefined,
+        report: false,
         exclude: undefined,
       });
+    });
+
+    it("sets report true when options.report is true", () => {
+      const result = parseArgs({
+        path: "/repo",
+        since: "12 months ago",
+        percentage: "10",
+        limit: "30",
+        couplingThreshold: "5",
+        report: true,
+        output: "report",
+      });
+      expect(result.report).toBe(true);
+      expect(result.output).toBe("report");
+    });
+
+    it("sets report false when options.report is absent", () => {
+      const result = parseArgs({
+        path: "/repo",
+        since: "12 months ago",
+        percentage: "10",
+        limit: "30",
+        couplingThreshold: "5",
+        output: "out.json",
+      });
+      expect(result.report).toBe(false);
     });
 
     it("parses percentage, limit, couplingThreshold as numbers", () => {
@@ -138,5 +165,25 @@ describe("parseArgs", () => {
         })
       ).toThrow("Invalid regex pattern: [invalid");
     });
+  });
+});
+
+describe("getReportOutputPaths", () => {
+  it("strips extension and returns .json and .md paths", () => {
+    const { jsonPath, reportPath } = getReportOutputPaths("report.md");
+    expect(jsonPath).toBe("report.json");
+    expect(reportPath).toBe("report.md");
+  });
+
+  it("uses path as base when it has no extension", () => {
+    const { jsonPath, reportPath } = getReportOutputPaths("out");
+    expect(jsonPath).toBe("out.json");
+    expect(reportPath).toBe("out.md");
+  });
+
+  it("strips extension and preserves directory", () => {
+    const { jsonPath, reportPath } = getReportOutputPaths("dir/report.md");
+    expect(jsonPath).toBe("dir/report.json");
+    expect(reportPath).toBe("dir/report.md");
   });
 });

--- a/src/args.ts
+++ b/src/args.ts
@@ -6,7 +6,23 @@ export interface HotspotArgs {
   limit: number;
   couplingThreshold: number;
   output?: string;
+  report?: boolean;
   exclude?: string[];
+}
+
+/**
+ * When --report is set, --output is a base path. Returns paths for JSON and report.
+ * Strips any extension from outputPath to form the base (e.g. "report.md" -> base "report").
+ */
+export function getReportOutputPaths(outputPath: string): {
+  jsonPath: string;
+  reportPath: string;
+} {
+  const base = outputPath.replace(/\.[^/.]+$/, "") || outputPath;
+  return {
+    jsonPath: `${base}.json`,
+    reportPath: `${base}.md`,
+  };
 }
 
 export function parseArgs(options: any): HotspotArgs {
@@ -44,6 +60,7 @@ export function parseArgs(options: any): HotspotArgs {
     limit,
     couplingThreshold,
     output: options.output,
+    report: options.report === true,
     exclude: excludePatterns.length > 0 ? excludePatterns : undefined,
   };
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { runHotspotter } from "./index.js";
+
+vi.mock("./analyze.js", () => ({
+  runAnalysis: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./analyzer.js", () => ({
+  analyzeHotspots: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("fs/promises", () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./dateResolver.js", () => ({
+  resolveDateRange: vi.fn().mockResolvedValue({
+    since: "2024-01-01T00:00:00.000Z",
+    until: "2025-01-01T00:00:00.000Z",
+  }),
+  getCommitRangeForRange: vi.fn().mockResolvedValue({}),
+}));
+
+const runAnalysis = (await import("./analyze.js")).runAnalysis as ReturnType<
+  typeof vi.fn
+>;
+
+describe("runHotspotter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when --report is set", () => {
+    it("invokes runAnalysis with derived json path, report path, and workspace path", async () => {
+      await runHotspotter({
+        path: "/some/repo",
+        since: "1 year ago",
+        percentage: "10",
+        limit: "30",
+        couplingThreshold: "5",
+        report: true,
+        output: "report",
+      });
+
+      expect(runAnalysis).toHaveBeenCalledTimes(1);
+      expect(runAnalysis).toHaveBeenCalledWith(
+        "report.json",
+        "report.md",
+        "/some/repo"
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Unifies the two scripts (`hotspotter` and `hotspotter-analyze`) into a single `hotspotter` command. Users control whether to run only data gathering or data gathering + report generation via the `--report` flag.

Closes #6

## Changes

### CLI
- **Single command**: `hotspotter` with optional `--report` flag.
- **Without `--report`**: Runs data gathering only; output is CSV to stdout or JSON to `--output` (unchanged behavior).
- **With `--report`**: Runs data gathering, then report generation. Requires `--output` as a base path; writes `{base}.json` and `{base}.md`.
- **`--output` semantics**: When `--report` is not set, `--output` is the literal JSON path. When `--report` is set, `--output` is the base (extension stripped) for both files.
- **Removed**: `hotspotter-analyze` from `package.json` bin. There is no separate analyze-only command.

### Code
- `src/index.ts`: Added `--report`, validation (require `--output` when `--report`), base-path derivation, call to `runAnalysis()`. Extracted `runHotspotter()` for testing; `program.parse()` skipped under Vitest.
- `src/args.ts`: Added `report` to `HotspotArgs`, `getReportOutputPaths(output)` for base-path derivation.
- `src/analyze.ts`: Refactored to export `runAnalysis(inputPath, outputPath, workspacePath)` only; removed Commander program and standalone entrypoint.

### Tests
- `src/args.test.ts`: Tests for `report` option and `getReportOutputPaths()` (strip extension, preserve directory).
- `src/index.test.ts`: Tests that when `--report` is set, `runAnalysis` is invoked with the correct paths (mocked).

### Specs
- `openspec/specs/hotspotter/spec.md`: Updated workflow (report via `--report`), `--output` and `--report` args, usage example.
- `openspec/specs/ai-analysis/spec.md`: Updated for report generation via `hotspotter --report`; removed standalone CLI.

### Archive
- Change `unify-hotspotter-cli` archived to `openspec/changes/archive/2026-02-03-unify-hotspotter-cli/`.